### PR TITLE
Bug fix on changing experiment type during analysis

### DIFF
--- a/server.R
+++ b/server.R
@@ -821,7 +821,7 @@ server <- function(input, output, session) {
    })
 
   ##### Get results dataframe from Summarizedexperiment object
-   data_result<-reactive({
+   data_result<-eventReactive(start_analysis(),{
       get_results_proteins(dep(), input$exp)
       #get_results(dep())
     })
@@ -1223,7 +1223,7 @@ output$download_imp_svg<-downloadHandler(
 )
 
   #### Occurrence page logic ####
-  data_attendance<-reactive({
+  data_attendance<-eventReactive(start_analysis(),{
     conditions <- condition_list()
     
     


### PR DESCRIPTION
Fixed the issue that the Result table would reload on the Quantification and Absence/Presence Page if change the Experiment Type during analysis with an error appears.

**Before**
![image](https://user-images.githubusercontent.com/69587768/205815568-12ea3ff7-2fca-4eba-a4f8-92c07f4eb8f9.png)

**After**
![image](https://user-images.githubusercontent.com/69587768/205816838-d3451708-3b02-40c2-9343-8e80c3bacb33.png)

